### PR TITLE
changes in run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cp target/yb-sample-apps.jar /home/centos/code
 
 # TODO: build the ycsb code
 WORKDIR /home/centos/code/YCSB
-RUN mvn clean package -DskipTests
+RUN mvn -pl yugabyteSQL,yugabyteCQL -am clean package -DskipTests
 
 # change the working direcotry
 WORKDIR /home/centos

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ This includes following benchmarks pre-installed and ready to be used:
      Info about ycsb specific parameters can be found [here](https://github.com/yugabyte/ycsb).
     ```shell
     # load
-    docker run --name ybbench --rm -it yugabytedb/ybbench:latest ./run ycsb load basic -P workloads/workloada
+    docker run --name ybbench --rm -it yugabytedb/ybbench:latest ./run ycsb load yugabyteCQL -P yugabyteCQL/db.properties -P workloads/workloada
      
     # run
-    docker run --name ybbench --rm -it yugabytedb/ybbench:latest ./run ycsb run basic -P workloads/workloada
+    docker run --name ybbench --rm -it yugabytedb/ybbench:latest ./run ycsb run yugabyteCQL -P yugabyteCQL/db.properties -P workloads/workloada
     ```
     To modify the workload related properties in YCSB -[db.properties](https://github.com/yugabyte/YCSB/blob/master/yugabyteSQL/db.properties), you can mount the file as a volume.
     ```shell

--- a/run
+++ b/run
@@ -21,23 +21,23 @@ case $1 in
   tpccbenchmark)
     echo "***************************** TPCC BENCHMARK *********************************"
     cd /home/centos/code/tpcc
-    ./tpccbenchmark "$@"
+    ./tpccbenchmark "${@:2}"
     ;;
   sysbench)
     echo "***************************** SYSBENCH BENCHMARK *****************************"
     cd /home/centos/code/sysbench
-    "$@"
+    sysbench "${@:2}"
     ;;
   yb-sample-apps)
 
     echo "******************************* YB-SAMPLE-APPS *******************************"
     cd /home/centos/code/yb-sample-apps/target
-    java -jar yb-sample-apps.jar "$@"
+    java -jar yb-sample-apps.jar "${@:2}"
     ;;
   ycsb)
     echo "************************************ YCSB ************************************"
     cd /home/centos/code/YCSB
-    ./bin/ycsb "$@"
+    ./bin/ycsb "${@:2}"
     ;;
   *)
     echo


### PR DESCRIPTION
Changes:
1. Changed run script to forward required params to benchmark
2. Changed Dockerfile to just build the yugabyte specific binaries for YCSB. This reduced the image build time significantly. Also the docker image size is down to ~1.5GB from previous ~4.4GB
3. Added minor readme changes